### PR TITLE
feat: #47 Profile Screen API 연결

### DIFF
--- a/src/app/_main/main-screen.stories.tsx
+++ b/src/app/_main/main-screen.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof MainScreen> = {
   tags: ["autodocs"],
 }
 
-const userInfo = mockUserInfo
+const myInfo = mockUserInfo
 
 const Template: StoryFn<typeof MainScreen> = args => <MainScreen {...args} />
 
@@ -28,9 +28,9 @@ export const PrimaryFirst = Template.bind({})
 export const Phone = PhoneSize.bind({})
 export const PhoneFirst = PhoneSize.bind({})
 
-Primary.args = { isMainFirst: false, userInfo }
-PrimaryFirst.args = { isMainFirst: true, userInfo }
-Phone.args = { isMainFirst: false, userInfo }
-PhoneFirst.args = { isMainFirst: true, userInfo }
+Primary.args = { isMainFirst: false, myInfo }
+PrimaryFirst.args = { isMainFirst: true, myInfo }
+Phone.args = { isMainFirst: false, myInfo }
+PhoneFirst.args = { isMainFirst: true, myInfo }
 
 export default meta

--- a/src/app/_main/main-screen.stories.tsx
+++ b/src/app/_main/main-screen.stories.tsx
@@ -28,9 +28,9 @@ export const PrimaryFirst = Template.bind({})
 export const Phone = PhoneSize.bind({})
 export const PhoneFirst = PhoneSize.bind({})
 
-Primary.args = { isMainFirst: false, myInfo }
-PrimaryFirst.args = { isMainFirst: true, myInfo }
-Phone.args = { isMainFirst: false, myInfo }
-PhoneFirst.args = { isMainFirst: true, myInfo }
+Primary.args = { myInfo }
+PrimaryFirst.args = { myInfo }
+Phone.args = { myInfo }
+PhoneFirst.args = { myInfo }
 
 export default meta

--- a/src/app/_main/main-screen.tsx
+++ b/src/app/_main/main-screen.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export default function MainScreen({ userInfo, isMainFirst }: Props) {
   const [isFirst, setIsFirst] = useState(isMainFirst)
-  const { nickName, profileImage } = userInfo
+  const { nickname, profileImage } = userInfo
 
   const { push } = useFlow()
   const createGame = useAdminStore(state => state.createGame)
@@ -46,7 +46,7 @@ export default function MainScreen({ userInfo, isMainFirst }: Props) {
     <div className="relative h-full w-full bg-gray-950">
       <Drawer>
         {!isFirst && <MainOnboarding onboardingHandler={onboardingHandler} />}
-        <MainHeader userNickName={nickName} userProfileImage={profileImage} />
+        <MainHeader userNickName={nickname} userProfileImage={profileImage} />
         <MainFooter onCreateRoom={onCreateRoom} />
         <MainContent inviteWithCode={inviteWithCode} />
       </Drawer>

--- a/src/app/_main/main-screen.tsx
+++ b/src/app/_main/main-screen.tsx
@@ -14,11 +14,10 @@ import MainOnboarding from "./components/main-onboarding"
 
 type Props = {
   myInfo: UserMyInfoType
-  isMainFirst: boolean
 }
 
-export default function MainScreen({ myInfo, isMainFirst }: Props) {
-  const [isFirst, setIsFirst] = useState(() => isMainFirst)
+export default function MainScreen({ myInfo }: Props) {
+  const [isFirst, setIsFirst] = useState(() => (localStorage.getItem("main-first") ? false : true))
 
   const { replace } = useFlow()
   const createGame = useAdminStore(state => state.createGame)

--- a/src/app/_main/main-screen.tsx
+++ b/src/app/_main/main-screen.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 
 import { Drawer } from "@/components/drawer"
 import useAdminStore from "@/store/admin-store"
+import { UserInfoType } from "@/types/user"
 
 import { useFlow } from "../stackflow"
 import MainContent from "./components/main-content"
@@ -12,16 +13,13 @@ import MainHeader from "./components/main-header"
 import MainOnboarding from "./components/main-onboarding"
 
 type Props = {
-  userInfo: {
-    userNickName: string
-    userProfileImage: string
-  }
+  userInfo: UserInfoType
   isMainFirst: boolean
 }
 
 export default function MainScreen({ userInfo, isMainFirst }: Props) {
   const [isFirst, setIsFirst] = useState(isMainFirst)
-  const { userNickName, userProfileImage } = userInfo
+  const { nickName, profileImage } = userInfo
 
   const { push } = useFlow()
   const createGame = useAdminStore(state => state.createGame)
@@ -48,7 +46,7 @@ export default function MainScreen({ userInfo, isMainFirst }: Props) {
     <div className="relative h-full w-full bg-gray-950">
       <Drawer>
         {!isFirst && <MainOnboarding onboardingHandler={onboardingHandler} />}
-        <MainHeader userNickName={userNickName} userProfileImage={userProfileImage} />
+        <MainHeader userNickName={nickName} userProfileImage={profileImage} />
         <MainFooter onCreateRoom={onCreateRoom} />
         <MainContent inviteWithCode={inviteWithCode} />
       </Drawer>

--- a/src/app/_main/main-screen.tsx
+++ b/src/app/_main/main-screen.tsx
@@ -13,13 +13,13 @@ import MainHeader from "./components/main-header"
 import MainOnboarding from "./components/main-onboarding"
 
 type Props = {
-  userInfo: UserInfoType
+  myInfo: UserInfoType
   isMainFirst: boolean
 }
 
-export default function MainScreen({ userInfo, isMainFirst }: Props) {
+export default function MainScreen({ myInfo, isMainFirst }: Props) {
   const [isFirst, setIsFirst] = useState(isMainFirst)
-  const { nickname, profileImage } = userInfo
+  const { nickname, profileImage } = myInfo
 
   const { push } = useFlow()
   const createGame = useAdminStore(state => state.createGame)

--- a/src/app/_main/main-screen.tsx
+++ b/src/app/_main/main-screen.tsx
@@ -21,7 +21,7 @@ export default function MainScreen({ myInfo, isMainFirst }: Props) {
   const [isFirst, setIsFirst] = useState(isMainFirst)
   const { nickName, profileImage } = myInfo
 
-  const { push } = useFlow()
+  const { replace } = useFlow()
   const createGame = useAdminStore(state => state.createGame)
 
   const inviteWithCode = (e: FormData) => {
@@ -29,7 +29,7 @@ export default function MainScreen({ myInfo, isMainFirst }: Props) {
 
     if (typeof inviteCode !== "string") throw new Error("옳지 않은 접근입니다.")
 
-    push("Waiting", { code: inviteCode })
+    replace("Waiting", { roomId: inviteCode })
   }
 
   const onboardingHandler = () => {
@@ -39,7 +39,7 @@ export default function MainScreen({ myInfo, isMainFirst }: Props) {
 
   const onCreateRoom = () => {
     createGame()
-    push("Waiting", {})
+    replace("Waiting", {})
   }
 
   return (

--- a/src/app/_main/main-screen.tsx
+++ b/src/app/_main/main-screen.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export default function MainScreen({ myInfo, isMainFirst }: Props) {
   const [isFirst, setIsFirst] = useState(isMainFirst)
-  const { nickname, profileImage } = myInfo
+  const { nickName, profileImage } = myInfo
 
   const { push } = useFlow()
   const createGame = useAdminStore(state => state.createGame)
@@ -46,7 +46,7 @@ export default function MainScreen({ myInfo, isMainFirst }: Props) {
     <div className="relative h-full w-full bg-gray-950">
       <Drawer>
         {!isFirst && <MainOnboarding onboardingHandler={onboardingHandler} />}
-        <MainHeader userNickName={nickname} userProfileImage={profileImage} />
+        <MainHeader userNickName={nickName} userProfileImage={profileImage} />
         <MainFooter onCreateRoom={onCreateRoom} />
         <MainContent inviteWithCode={inviteWithCode} />
       </Drawer>

--- a/src/app/_main/main.tsx
+++ b/src/app/_main/main.tsx
@@ -3,16 +3,18 @@
 import { AppScreen } from "@stackflow/plugin-basic-ui"
 import { ActivityComponentType } from "@stackflow/react"
 
-import { mockUserInfo } from "@/seeds/user-mock"
+import useMyInfoStore from "@/store/my-info-store"
 
 import MainScreen from "./main-screen"
 
 const Main: ActivityComponentType = () => {
-  if (typeof window === "undefined") return
+  const myInfo = useMyInfoStore(state => state.myInfo)
+
+  if (typeof window === "undefined" || !myInfo) return
   const isMainFirst = localStorage.getItem("main-first") ? true : false
   return (
     <AppScreen>
-      <MainScreen isMainFirst={isMainFirst} userInfo={mockUserInfo} />
+      <MainScreen isMainFirst={isMainFirst} myInfo={myInfo} />
     </AppScreen>
   )
 }

--- a/src/app/_profile/api/post-profile.ts
+++ b/src/app/_profile/api/post-profile.ts
@@ -8,7 +8,7 @@ export type PostProfileResponse = {
   profileImage: string
 }
 
-export const postProfile = async (BodyData: UserInfoType, roomId?: string) => {
+export const postProfile = async (BodyData: UserInfoType, roomId: string | null) => {
   try {
     const url = END_POINT.user + (roomId ? `?rooId=${roomId}` : "")
     const res = await axiosInstance.post<PostProfileResponse>(url, { ...BodyData })

--- a/src/app/_profile/api/post-profile.ts
+++ b/src/app/_profile/api/post-profile.ts
@@ -1,0 +1,21 @@
+import { END_POINT } from "@/constants/apis"
+import { axiosInstance } from "@/libs/axios/instance"
+import { UserInfoType } from "@/types/user"
+
+export type PostProfileResponse = {
+  id: number
+  displayName: string
+  profileImage: string
+}
+
+export const postProfile = async (BodyData: UserInfoType, roomId?: string) => {
+  try {
+    const url = END_POINT.user + (roomId ? `?rooId=${roomId}` : "")
+    const res = await axiosInstance.post<PostProfileResponse>(url, { ...BodyData })
+    return res.data
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(error.message)
+    }
+  }
+}

--- a/src/app/_profile/profile-screen.tsx
+++ b/src/app/_profile/profile-screen.tsx
@@ -3,18 +3,18 @@ import Image from "next/image"
 import EditProfile from "@/assets/svgs/profiles/edit-profile.svg"
 import { Avatar, AvatarFallback } from "@/components/avatar"
 import { Drawer, DrawerClose, DrawerContent, DrawerTrigger } from "@/components/drawer"
+import { UserInfoType } from "@/types/user"
 
 import ProfileInput from "./components/profile-input/profile-input"
 import { PROFILE_THEMES } from "./profile-themes"
 
 type Props = {
   profile: any
-  nickname: string
   onDrawerClick: (profileTheme: any) => void
   onInputChange: (value: string) => void
-}
+} & Pick<UserInfoType, "nickName">
 
-export default function ProfileScreen({ profile, nickname, onDrawerClick, onInputChange }: Props) {
+export default function ProfileScreen({ profile, nickName, onDrawerClick, onInputChange }: Props) {
   return (
     <div className="min-h-full bg-gray-950 px-[49px]">
       <div className="mb-[33px] flex justify-center">
@@ -50,7 +50,7 @@ export default function ProfileScreen({ profile, nickname, onDrawerClick, onInpu
         </Drawer>
       </div>
 
-      <ProfileInput nickname={nickname} onInputChange={onInputChange} />
+      <ProfileInput nickname={nickName} onInputChange={onInputChange} />
 
       <div className="flex flex-col items-center text-sm text-[#F2F4F7]">
         <p>얼음땡에서 사용할 닉네임과 프로필을 설정해주세요.</p>

--- a/src/app/_profile/profile.tsx
+++ b/src/app/_profile/profile.tsx
@@ -3,27 +3,30 @@ import { ActivityComponentType } from "@stackflow/react"
 import { useState } from "react"
 
 import FallbackProfile from "@/assets/svgs/profiles/fallback-profile.svg"
+import useMyInfoStore from "@/store/my-info-store"
 
 import { useFlow } from "../stackflow"
 import ProfileScreen from "./profile-screen"
 
 const Profile: ActivityComponentType = () => {
-  const [profile, setProfile] = useState(FallbackProfile)
   const [nickname, setNickname] = useState("")
+  const [profileImage, setProfileImage] = useState(FallbackProfile)
+  const setMyInfo = useMyInfoStore(state => state.setMyInfo)
 
   const { replace } = useFlow()
 
   const onDrawerClick = (profileTheme: any) => {
-    setProfile(profileTheme)
+    setProfileImage(profileTheme)
   }
 
   const onInputChange = (nickname: string) => {
     setNickname(nickname)
   }
 
-  const finish = profile !== FallbackProfile && nickname !== ""
+  const finish = profileImage !== FallbackProfile && nickname !== ""
 
   const onSubmit = () => {
+    setMyInfo({ nickname, profileImage })
     replace("Main", {})
   }
 
@@ -45,8 +48,8 @@ const Profile: ActivityComponentType = () => {
       }}
     >
       <ProfileScreen
-        profile={profile}
         nickname={nickname}
+        profile={profileImage}
         onDrawerClick={onDrawerClick}
         onInputChange={onInputChange}
       />

--- a/src/app/_profile/profile.tsx
+++ b/src/app/_profile/profile.tsx
@@ -23,19 +23,17 @@ const Profile: ActivityComponentType = () => {
 
   const finish = profile !== FallbackProfile && nickname !== ""
 
+  const onSubmit = () => {
+    replace("Main", {})
+  }
+
   return (
     <AppScreen
       appBar={{
         title: "프로필 설정하기",
         renderRight: () => {
           return (
-            <button
-              disabled={!finish}
-              onClick={() => {
-                replace("Main", {})
-              }}
-              className="pr-[27px] text-gray-100 disabled:text-gray-600"
-            >
+            <button disabled={!finish} onClick={onSubmit} className="pr-[27px] text-gray-100 disabled:text-gray-600">
               완료
             </button>
           )

--- a/src/app/_profile/profile.tsx
+++ b/src/app/_profile/profile.tsx
@@ -26,7 +26,7 @@ const Profile: ActivityComponentType = () => {
   const finish = profileImage !== FallbackProfile && nickname !== ""
 
   const onSubmit = () => {
-    setMyInfo({ nickname, profileImage })
+    setMyInfo({ nickname, profileImage: profileImage.src })
     replace("Main", {})
   }
 

--- a/src/app/_profile/profile.tsx
+++ b/src/app/_profile/profile.tsx
@@ -28,13 +28,20 @@ const Profile: ActivityComponentType = () => {
 
   const onSubmit = async () => {
     try {
-      const res = await postProfile({ nickName, profileImage: profileImage.src })
+      const urlParams = new URL(location.href).searchParams
+      const roomId = urlParams.get("roomId")
+
+      const res = await postProfile({ nickName, profileImage: profileImage.src }, roomId)
 
       if (!res) throw new Error("사용자 정보 생성에 실패하였습니다.")
 
       setMyInfo(res)
 
-      replace("Main", {})
+      if (roomId) {
+        replace("Waiting", { roomId })
+      } else {
+        replace("Main", {})
+      }
     } catch (err) {
       if (err instanceof Error) {
         console.error(err.message)

--- a/src/app/_profile/profile.tsx
+++ b/src/app/_profile/profile.tsx
@@ -6,28 +6,40 @@ import FallbackProfile from "@/assets/svgs/profiles/fallback-profile.svg"
 import useMyInfoStore from "@/store/my-info-store"
 
 import { useFlow } from "../stackflow"
+import { postProfile } from "./api/post-profile"
 import ProfileScreen from "./profile-screen"
 
 const Profile: ActivityComponentType = () => {
-  const [nickname, setNickname] = useState("")
+  const [nickName, setNickName] = useState("")
   const [profileImage, setProfileImage] = useState(FallbackProfile)
   const setMyInfo = useMyInfoStore(state => state.setMyInfo)
 
   const { replace } = useFlow()
 
-  const onDrawerClick = (profileTheme: any) => {
-    setProfileImage(profileTheme)
+  const onDrawerClick = (newProfile: string) => {
+    setProfileImage(newProfile)
   }
 
-  const onInputChange = (nickname: string) => {
-    setNickname(nickname)
+  const onInputChange = (newName: string) => {
+    setNickName(newName)
   }
 
-  const finish = profileImage !== FallbackProfile && nickname !== ""
+  const finish = profileImage !== FallbackProfile && nickName !== ""
 
-  const onSubmit = () => {
-    setMyInfo({ nickname, profileImage: profileImage.src })
-    replace("Main", {})
+  const onSubmit = async () => {
+    try {
+      const res = await postProfile({ nickName, profileImage: profileImage.src })
+
+      if (!res) throw new Error("사용자 정보 생성에 실패하였습니다.")
+
+      setMyInfo(res)
+
+      replace("Main", {})
+    } catch (err) {
+      if (err instanceof Error) {
+        console.error(err.message)
+      }
+    }
   }
 
   return (
@@ -48,7 +60,7 @@ const Profile: ActivityComponentType = () => {
       }}
     >
       <ProfileScreen
-        nickname={nickname}
+        nickName={nickName}
         profile={profileImage}
         onDrawerClick={onDrawerClick}
         onInputChange={onInputChange}

--- a/src/app/_small-talk/components/game-banner/game-banner.stories.tsx
+++ b/src/app/_small-talk/components/game-banner/game-banner.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof SmallTalkGameBanner> = {
 }
 
 const selectAnswer = mockSelectAnswer
-const { nickname } = mockUserInfo
+const { nickName } = mockUserInfo
 const topic = mockTopic
 
 const Template: StoryFn<typeof SmallTalkGameBanner> = args => <SmallTalkGameBanner {...args} />
@@ -28,8 +28,8 @@ export const Primary = Template.bind({})
 export const PhoneRandom = PhoneSize.bind({})
 export const PhoneResult = PhoneSize.bind({})
 
-Primary.args = { type: "random", topic, selectAnswer, nickname }
-PhoneRandom.args = { type: "random", topic, selectAnswer, nickname }
-PhoneResult.args = { type: "result", topic, selectAnswer, nickname }
+Primary.args = { type: "random", topic, selectAnswer, nickName }
+PhoneRandom.args = { type: "random", topic, selectAnswer, nickName }
+PhoneResult.args = { type: "result", topic, selectAnswer, nickName }
 
 export default meta

--- a/src/app/_small-talk/components/game-banner/game-banner.stories.tsx
+++ b/src/app/_small-talk/components/game-banner/game-banner.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof SmallTalkGameBanner> = {
 }
 
 const selectAnswer = mockSelectAnswer
-const { userNickName } = mockUserInfo
+const { nickName } = mockUserInfo
 const topic = mockTopic
 
 const Template: StoryFn<typeof SmallTalkGameBanner> = args => <SmallTalkGameBanner {...args} />
@@ -28,8 +28,8 @@ export const Primary = Template.bind({})
 export const PhoneRandom = PhoneSize.bind({})
 export const PhoneResult = PhoneSize.bind({})
 
-Primary.args = { type: "random", topic, selectAnswer, userNickName }
-PhoneRandom.args = { type: "random", topic, selectAnswer, userNickName }
-PhoneResult.args = { type: "result", topic, selectAnswer, userNickName }
+Primary.args = { type: "random", topic, selectAnswer, nickName }
+PhoneRandom.args = { type: "random", topic, selectAnswer, nickName }
+PhoneResult.args = { type: "result", topic, selectAnswer, nickName }
 
 export default meta

--- a/src/app/_small-talk/components/game-banner/game-banner.stories.tsx
+++ b/src/app/_small-talk/components/game-banner/game-banner.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof SmallTalkGameBanner> = {
 }
 
 const selectAnswer = mockSelectAnswer
-const { nickName } = mockUserInfo
+const { nickname } = mockUserInfo
 const topic = mockTopic
 
 const Template: StoryFn<typeof SmallTalkGameBanner> = args => <SmallTalkGameBanner {...args} />
@@ -28,8 +28,8 @@ export const Primary = Template.bind({})
 export const PhoneRandom = PhoneSize.bind({})
 export const PhoneResult = PhoneSize.bind({})
 
-Primary.args = { type: "random", topic, selectAnswer, nickName }
-PhoneRandom.args = { type: "random", topic, selectAnswer, nickName }
-PhoneResult.args = { type: "result", topic, selectAnswer, nickName }
+Primary.args = { type: "random", topic, selectAnswer, nickname }
+PhoneRandom.args = { type: "random", topic, selectAnswer, nickname }
+PhoneResult.args = { type: "result", topic, selectAnswer, nickname }
 
 export default meta

--- a/src/app/_small-talk/components/game-banner/game-banner.tsx
+++ b/src/app/_small-talk/components/game-banner/game-banner.tsx
@@ -8,16 +8,16 @@ type Props = {
   topic: string
   className?: string
   selectAnswer?: string
-} & Partial<Pick<UserInfoType, "nickname">>
+} & Partial<Pick<UserInfoType, "nickName">>
 
-export default function SmallTalkGameBanner({ type, topic, selectAnswer, className, nickname }: Props) {
+export default function SmallTalkGameBanner({ type, topic, selectAnswer, className, nickName }: Props) {
   const bannerContent = useMemo(() => {
     if (type === "random") {
       return { title: "빈칸 주제", content: "ㅤㅤ?ㅤㅤ" }
     } else {
-      return { title: `${nickname} 님의 답변`, content: selectAnswer }
+      return { title: `${nickName} 님의 답변`, content: selectAnswer }
     }
-  }, [type, selectAnswer, nickname])
+  }, [type, selectAnswer, nickName])
 
   return (
     <div className={cn("h-[180px] rounded-[14px] bg-gray-100 px-[22px] py-[21px] text-center", className)}>

--- a/src/app/_small-talk/components/game-banner/game-banner.tsx
+++ b/src/app/_small-talk/components/game-banner/game-banner.tsx
@@ -6,18 +6,18 @@ type Props = {
   type: "random" | "result"
   topic: string
   className?: string
-  userNickName?: string
+  nickName?: string
   selectAnswer?: string
 }
 
-export default function SmallTalkGameBanner({ type, topic, selectAnswer, className, userNickName }: Props) {
+export default function SmallTalkGameBanner({ type, topic, selectAnswer, className, nickName }: Props) {
   const bannerContent = useMemo(() => {
     if (type === "random") {
       return { title: "빈칸 주제", content: "ㅤㅤ?ㅤㅤ" }
     } else {
-      return { title: `${userNickName} 님의 답변`, content: selectAnswer }
+      return { title: `${nickName} 님의 답변`, content: selectAnswer }
     }
-  }, [type, selectAnswer, userNickName])
+  }, [type, selectAnswer, nickName])
 
   return (
     <div className={cn("h-[180px] rounded-[14px] bg-gray-100 px-[22px] py-[21px] text-center", className)}>

--- a/src/app/_small-talk/components/game-banner/game-banner.tsx
+++ b/src/app/_small-talk/components/game-banner/game-banner.tsx
@@ -1,23 +1,23 @@
 import { useMemo } from "react"
 
 import { cn } from "@/libs/tailwind/cn"
+import { UserInfoType } from "@/types/user"
 
 type Props = {
   type: "random" | "result"
   topic: string
   className?: string
-  nickName?: string
   selectAnswer?: string
-}
+} & Partial<Pick<UserInfoType, "nickname">>
 
-export default function SmallTalkGameBanner({ type, topic, selectAnswer, className, nickName }: Props) {
+export default function SmallTalkGameBanner({ type, topic, selectAnswer, className, nickname }: Props) {
   const bannerContent = useMemo(() => {
     if (type === "random") {
       return { title: "빈칸 주제", content: "ㅤㅤ?ㅤㅤ" }
     } else {
-      return { title: `${nickName} 님의 답변`, content: selectAnswer }
+      return { title: `${nickname} 님의 답변`, content: selectAnswer }
     }
-  }, [type, selectAnswer, nickName])
+  }, [type, selectAnswer, nickname])
 
   return (
     <div className={cn("h-[180px] rounded-[14px] bg-gray-100 px-[22px] py-[21px] text-center", className)}>

--- a/src/app/_small-talk/components/game-body/game-body.tsx
+++ b/src/app/_small-talk/components/game-body/game-body.tsx
@@ -11,14 +11,14 @@ type Props = {
 }
 
 export default function SmallTalkGameBody({ myInfo, children, className }: PropsWithChildren<Props>) {
-  const { userNickName, userProfileImage } = myInfo
+  const { nickName, profileImage } = myInfo
   return (
     <div className={cn("relative h-[412px] w-full", className)}>
       <div className="relative mx-auto my-0 h-[354px] w-[calc(100%-62px)]">
         <div className="absolute z-[3] flex h-[354px] w-full justify-center rounded-[20px] bg-gray-100">
           <Avatar className="absolute h-[124px] w-[124px] translate-y-[-50%] drop-shadow">
-            <AvatarImage src={userProfileImage} />
-            <AvatarFallback>{userNickName}</AvatarFallback>
+            <AvatarImage src={profileImage} />
+            <AvatarFallback>{nickName}</AvatarFallback>
           </Avatar>
           {children}
         </div>

--- a/src/app/_small-talk/components/game-body/game-body.tsx
+++ b/src/app/_small-talk/components/game-body/game-body.tsx
@@ -11,14 +11,14 @@ type Props = {
 }
 
 export default function SmallTalkGameBody({ myInfo, children, className }: PropsWithChildren<Props>) {
-  const { nickName, profileImage } = myInfo
+  const { nickname, profileImage } = myInfo
   return (
     <div className={cn("relative h-[412px] w-full", className)}>
       <div className="relative mx-auto my-0 h-[354px] w-[calc(100%-62px)]">
         <div className="absolute z-[3] flex h-[354px] w-full justify-center rounded-[20px] bg-gray-100">
           <Avatar className="absolute h-[124px] w-[124px] translate-y-[-50%] drop-shadow">
             <AvatarImage src={profileImage} />
-            <AvatarFallback>{nickName}</AvatarFallback>
+            <AvatarFallback>{nickname}</AvatarFallback>
           </Avatar>
           {children}
         </div>

--- a/src/app/_small-talk/components/game-body/game-body.tsx
+++ b/src/app/_small-talk/components/game-body/game-body.tsx
@@ -11,14 +11,14 @@ type Props = {
 }
 
 export default function SmallTalkGameBody({ myInfo, children, className }: PropsWithChildren<Props>) {
-  const { nickname, profileImage } = myInfo
+  const { nickName, profileImage } = myInfo
   return (
     <div className={cn("relative h-[412px] w-full", className)}>
       <div className="relative mx-auto my-0 h-[354px] w-[calc(100%-62px)]">
         <div className="absolute z-[3] flex h-[354px] w-full justify-center rounded-[20px] bg-gray-100">
           <Avatar className="absolute h-[124px] w-[124px] translate-y-[-50%] drop-shadow">
             <AvatarImage src={profileImage} />
-            <AvatarFallback>{nickname}</AvatarFallback>
+            <AvatarFallback>{nickName}</AvatarFallback>
           </Avatar>
           {children}
         </div>

--- a/src/app/_small-talk/game-input/game-input-screen.stories.tsx
+++ b/src/app/_small-talk/game-input/game-input-screen.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react"
 
 import { mockTopic } from "@/seeds/small-talk-mock"
-import { mockUserInfo } from "@/seeds/user-mock"
+import { mockMyUserInfo } from "@/seeds/user-mock"
 
 import SmallTalkGameInputScreen from "./game-input-screen"
 
@@ -12,7 +12,7 @@ const meta: Meta<typeof SmallTalkGameInputScreen> = {
 }
 
 const topic = mockTopic
-const myInfo = mockUserInfo
+const myInfo = mockMyUserInfo
 
 const Template: StoryFn<typeof SmallTalkGameInputScreen> = args => <SmallTalkGameInputScreen {...args} />
 

--- a/src/app/_small-talk/game-input/game-input-screen.tsx
+++ b/src/app/_small-talk/game-input/game-input-screen.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react"
 
 import { cn } from "@/libs/tailwind/cn"
-import { UserInfoType } from "@/types/user"
+import type { UserMyInfoType } from "@/types/user"
 
 import SmallTalkGameBody from "../components/game-body/game-body"
 import SmallTalkGameHeader from "../components/game-header/game-header"
 
 type Props = {
-  myInfo: UserInfoType
+  myInfo: UserMyInfoType
   topic: string
 }
 

--- a/src/app/_small-talk/game-input/index.tsx
+++ b/src/app/_small-talk/game-input/index.tsx
@@ -2,11 +2,12 @@ import { AppScreen } from "@stackflow/plugin-basic-ui"
 import { ActivityComponentType } from "@stackflow/react"
 
 import { mockTopic } from "@/seeds/small-talk-mock"
-import { mockUserInfo } from "@/seeds/user-mock"
+import useMyInfoStore from "@/store/my-info-store"
 
 import SmallTalkGameInputScreen from "./game-input-screen"
 
 const SmallTalkGameInput: ActivityComponentType = () => {
+  const myInfo = useMyInfoStore(state => state.myInfo)
   // const { push } = useFlow()
 
   // const _setRandom = useCallback(() => {
@@ -15,7 +16,7 @@ const SmallTalkGameInput: ActivityComponentType = () => {
 
   return (
     <AppScreen>
-      <SmallTalkGameInputScreen myInfo={mockUserInfo} topic={mockTopic} />
+      <SmallTalkGameInputScreen myInfo={myInfo} topic={mockTopic} />
     </AppScreen>
   )
 }

--- a/src/app/_small-talk/game-input/index.tsx
+++ b/src/app/_small-talk/game-input/index.tsx
@@ -14,6 +14,8 @@ const SmallTalkGameInput: ActivityComponentType = () => {
   //   push("SmallTalkRandom", {})
   // }, [push])
 
+  if (!myInfo) return
+
   return (
     <AppScreen>
       <SmallTalkGameInputScreen myInfo={myInfo} topic={mockTopic} />

--- a/src/app/_small-talk/game-result/game-result-screen.tsx
+++ b/src/app/_small-talk/game-result/game-result-screen.tsx
@@ -23,7 +23,7 @@ type Props = {
 }
 
 export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selectAnswer, isAdmin }: Props) {
-  const { nickname, profileImage } = selectUserInfo
+  const { nickName, profileImage } = selectUserInfo
 
   const [isAnimationVisible, setIsAnimationVisible] = useState(true)
   const [isResetHintVisible, setIsResetHintVisible] = useState(true)
@@ -53,7 +53,7 @@ export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selec
           type="result"
           className="mt-[85px]"
           topic={topic}
-          nickname={nickname}
+          nickName={nickName}
           selectAnswer={selectAnswer}
         />
         <SmallTalkGameResultBox>
@@ -73,9 +73,9 @@ export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selec
           <div className="flex h-full flex-col items-center justify-center">
             <Avatar className="h-[124px] w-[124px]">
               <AvatarImage src={profileImage} />
-              <AvatarFallback>{nickname}</AvatarFallback>
+              <AvatarFallback>{nickName}</AvatarFallback>
             </Avatar>
-            <div className="mt-[20px] text-[18px] font-semibold text-gray-100">{`${nickname}님 썰을 풀어주세요!`}</div>
+            <div className="mt-[20px] text-[18px] font-semibold text-gray-100">{`${nickName}님 썰을 풀어주세요!`}</div>
           </div>
         </SmallTalkGameResultBox>
         <div className="flex h-full gap-5">

--- a/src/app/_small-talk/game-result/game-result-screen.tsx
+++ b/src/app/_small-talk/game-result/game-result-screen.tsx
@@ -23,7 +23,7 @@ type Props = {
 }
 
 export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selectAnswer, isAdmin }: Props) {
-  const { userNickName, userProfileImage } = selectUserInfo
+  const { nickName, profileImage } = selectUserInfo
 
   const [isAnimationVisible, setIsAnimationVisible] = useState(true)
   const [isResetHintVisible, setIsResetHintVisible] = useState(true)
@@ -53,7 +53,7 @@ export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selec
           type="result"
           className="mt-[85px]"
           topic={topic}
-          userNickName={selectUserInfo.userNickName}
+          nickName={nickName}
           selectAnswer={selectAnswer}
         />
         <SmallTalkGameResultBox>
@@ -72,10 +72,10 @@ export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selec
           )}
           <div className="flex h-full flex-col items-center justify-center">
             <Avatar className="h-[124px] w-[124px]">
-              <AvatarImage src={userProfileImage} />
-              <AvatarFallback>{userNickName}</AvatarFallback>
+              <AvatarImage src={profileImage} />
+              <AvatarFallback>{nickName}</AvatarFallback>
             </Avatar>
-            <div className="mt-[20px] text-[18px] font-semibold text-gray-100">{`${userNickName}님 썰을 풀어주세요!`}</div>
+            <div className="mt-[20px] text-[18px] font-semibold text-gray-100">{`${nickName}님 썰을 풀어주세요!`}</div>
           </div>
         </SmallTalkGameResultBox>
         <div className="flex h-full gap-5">

--- a/src/app/_small-talk/game-result/game-result-screen.tsx
+++ b/src/app/_small-talk/game-result/game-result-screen.tsx
@@ -23,7 +23,7 @@ type Props = {
 }
 
 export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selectAnswer, isAdmin }: Props) {
-  const { nickName, profileImage } = selectUserInfo
+  const { nickname, profileImage } = selectUserInfo
 
   const [isAnimationVisible, setIsAnimationVisible] = useState(true)
   const [isResetHintVisible, setIsResetHintVisible] = useState(true)
@@ -53,7 +53,7 @@ export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selec
           type="result"
           className="mt-[85px]"
           topic={topic}
-          nickName={nickName}
+          nickname={nickname}
           selectAnswer={selectAnswer}
         />
         <SmallTalkGameResultBox>
@@ -73,9 +73,9 @@ export default function SmallTalkGameResultScreen({ topic, selectUserInfo, selec
           <div className="flex h-full flex-col items-center justify-center">
             <Avatar className="h-[124px] w-[124px]">
               <AvatarImage src={profileImage} />
-              <AvatarFallback>{nickName}</AvatarFallback>
+              <AvatarFallback>{nickname}</AvatarFallback>
             </Avatar>
-            <div className="mt-[20px] text-[18px] font-semibold text-gray-100">{`${nickName}님 썰을 풀어주세요!`}</div>
+            <div className="mt-[20px] text-[18px] font-semibold text-gray-100">{`${nickname}님 썰을 풀어주세요!`}</div>
           </div>
         </SmallTalkGameResultBox>
         <div className="flex h-full gap-5">

--- a/src/app/_waiting/components/waiting-bottom/one-user.tsx
+++ b/src/app/_waiting/components/waiting-bottom/one-user.tsx
@@ -10,7 +10,7 @@ type Props = {
 }
 
 export default function OneUser({ userInfo, index }: Props) {
-  const { nickname, profileImage, status } = userInfo
+  const { nickName, profileImage, status } = userInfo
 
   const isAdmin = index === 1
   const chipClassName = cn(
@@ -36,9 +36,9 @@ export default function OneUser({ userInfo, index }: Props) {
         <div className="text-[20px]">{index}</div>
         <Avatar className="h-[54px] w-[54px]">
           <AvatarImage src={profileImage} />
-          <AvatarFallback>{nickname}</AvatarFallback>
+          <AvatarFallback>{nickName}</AvatarFallback>
         </Avatar>
-        <div className="text-[20px]">{nickname}</div>
+        <div className="text-[20px]">{nickName}</div>
       </div>
       <div className={chipClassName}>{userStatus}</div>
     </div>

--- a/src/app/_waiting/components/waiting-bottom/one-user.tsx
+++ b/src/app/_waiting/components/waiting-bottom/one-user.tsx
@@ -10,7 +10,7 @@ type Props = {
 }
 
 export default function OneUser({ userInfo, index }: Props) {
-  const { nickName, profileImage, status } = userInfo
+  const { nickname, profileImage, status } = userInfo
 
   const isAdmin = index === 1
   const chipClassName = cn(
@@ -36,9 +36,9 @@ export default function OneUser({ userInfo, index }: Props) {
         <div className="text-[20px]">{index}</div>
         <Avatar className="h-[54px] w-[54px]">
           <AvatarImage src={profileImage} />
-          <AvatarFallback>{nickName}</AvatarFallback>
+          <AvatarFallback>{nickname}</AvatarFallback>
         </Avatar>
-        <div className="text-[20px]">{nickName}</div>
+        <div className="text-[20px]">{nickname}</div>
       </div>
       <div className={chipClassName}>{userStatus}</div>
     </div>

--- a/src/app/_waiting/components/waiting-top/index.tsx
+++ b/src/app/_waiting/components/waiting-top/index.tsx
@@ -9,7 +9,7 @@ type Props = {
 }
 
 export default function WaitingTop({ myInfo, disConnectRoom }: Props) {
-  const { nickName, profileImage } = myInfo
+  const { nickname, profileImage } = myInfo
   const { pop } = useFlow()
 
   const onBackClick = () => {
@@ -21,10 +21,10 @@ export default function WaitingTop({ myInfo, disConnectRoom }: Props) {
     <>
       <AppBar title="대기방" isBackButton onBackClick={onBackClick} />
       <section className="items-col flex flex-col items-center justify-center gap-[30px]">
-        <span className="whitespace-pre text-center align-text-top text-[26px] font-bold leading-tight text-gray-100">{`${nickName}님,\n팀원들이 들어오고 있어요`}</span>
+        <span className="whitespace-pre text-center align-text-top text-[26px] font-bold leading-tight text-gray-100">{`${nickname}님,\n팀원들이 들어오고 있어요`}</span>
         <Avatar className="h-[106px] w-[106px]">
           <AvatarImage src={profileImage} />
-          <AvatarFallback>{nickName}</AvatarFallback>
+          <AvatarFallback>{nickname}</AvatarFallback>
         </Avatar>
       </section>
     </>

--- a/src/app/_waiting/components/waiting-top/index.tsx
+++ b/src/app/_waiting/components/waiting-top/index.tsx
@@ -9,7 +9,7 @@ type Props = {
 }
 
 export default function WaitingTop({ myInfo, disConnectRoom }: Props) {
-  const { userNickName, userProfileImage } = myInfo
+  const { nickName, profileImage } = myInfo
   const { pop } = useFlow()
 
   const onBackClick = () => {
@@ -21,10 +21,10 @@ export default function WaitingTop({ myInfo, disConnectRoom }: Props) {
     <>
       <AppBar title="대기방" isBackButton onBackClick={onBackClick} />
       <section className="items-col flex flex-col items-center justify-center gap-[30px]">
-        <span className="whitespace-pre text-center align-text-top text-[26px] font-bold leading-tight text-gray-100">{`${userNickName}님,\n팀원들이 들어오고 있어요`}</span>
+        <span className="whitespace-pre text-center align-text-top text-[26px] font-bold leading-tight text-gray-100">{`${nickName}님,\n팀원들이 들어오고 있어요`}</span>
         <Avatar className="h-[106px] w-[106px]">
-          <AvatarImage src={userProfileImage} />
-          <AvatarFallback>{userNickName}</AvatarFallback>
+          <AvatarImage src={profileImage} />
+          <AvatarFallback>{nickName}</AvatarFallback>
         </Avatar>
       </section>
     </>

--- a/src/app/_waiting/components/waiting-top/index.tsx
+++ b/src/app/_waiting/components/waiting-top/index.tsx
@@ -9,7 +9,7 @@ type Props = {
 }
 
 export default function WaitingTop({ myInfo, disConnectRoom }: Props) {
-  const { nickname, profileImage } = myInfo
+  const { nickName, profileImage } = myInfo
   const { pop } = useFlow()
 
   const onBackClick = () => {
@@ -21,10 +21,10 @@ export default function WaitingTop({ myInfo, disConnectRoom }: Props) {
     <>
       <AppBar title="대기방" isBackButton onBackClick={onBackClick} />
       <section className="items-col flex flex-col items-center justify-center gap-[30px]">
-        <span className="whitespace-pre text-center align-text-top text-[26px] font-bold leading-tight text-gray-100">{`${nickname}님,\n팀원들이 들어오고 있어요`}</span>
+        <span className="whitespace-pre text-center align-text-top text-[26px] font-bold leading-tight text-gray-100">{`${nickName}님,\n팀원들이 들어오고 있어요`}</span>
         <Avatar className="h-[106px] w-[106px]">
           <AvatarImage src={profileImage} />
-          <AvatarFallback>{nickname}</AvatarFallback>
+          <AvatarFallback>{nickName}</AvatarFallback>
         </Avatar>
       </section>
     </>

--- a/src/app/_waiting/types/game.ts
+++ b/src/app/_waiting/types/game.ts
@@ -1,8 +1,8 @@
+import { UserInfoType } from "@/types/user"
+
 export type RoleType = "방장" | "팀원"
 
 export type UserWaitingType = {
   id: number
-  nickName: string
-  profileImage: string
   status: boolean
-}
+} & UserInfoType

--- a/src/app/_waiting/waiting.tsx
+++ b/src/app/_waiting/waiting.tsx
@@ -39,7 +39,9 @@ const Waiting: ActivityComponentType = () => {
     }
   }, [isAdmin, roomId])
 
-  if (typeof roomId === "undefined" && !isAdmin) return
+  const inNotUser = typeof roomId === "undefined" && !isAdmin
+
+  if (inNotUser || !myInfo) return
 
   return (
     <AppScreen>

--- a/src/app/_waiting/waiting.tsx
+++ b/src/app/_waiting/waiting.tsx
@@ -4,8 +4,9 @@ import { AppScreen } from "@stackflow/plugin-basic-ui"
 import { ActivityComponentType, useActivity } from "@stackflow/react"
 import { useEffect } from "react"
 
-import { mockUserInfo, mockUserList } from "@/seeds/user-mock"
+import { mockUserList } from "@/seeds/user-mock"
 import useAdminStore from "@/store/admin-store"
+import useMyInfoStore from "@/store/my-info-store"
 
 import WaitingScreen from "./waiting-screen"
 
@@ -13,6 +14,7 @@ const Waiting: ActivityComponentType = () => {
   const isAdmin = useAdminStore()
   const { params } = useActivity()
 
+  const myInfo = useMyInfoStore(state => state.myInfo)
   const roomId = params.roomId
 
   // const { replace } = useFlow()
@@ -41,7 +43,7 @@ const Waiting: ActivityComponentType = () => {
 
   return (
     <AppScreen>
-      <WaitingScreen roomId="받아온 초대코드" myInfo={mockUserInfo} userList={mockUserList} />
+      <WaitingScreen roomId="받아온 초대코드" myInfo={myInfo} userList={mockUserList} />
     </AppScreen>
   )
 }

--- a/src/constants/apis.ts
+++ b/src/constants/apis.ts
@@ -6,4 +6,5 @@ export const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL
 
 export const END_POINT = {
   temp: "/temp",
+  user: "/user",
 }

--- a/src/seeds/user-mock.ts
+++ b/src/seeds/user-mock.ts
@@ -1,7 +1,13 @@
 import { UserWaitingType } from "@/app/_waiting/types/game"
-import { UserInfoType } from "@/types/user"
+import { UserInfoType, UserMyInfoType } from "@/types/user"
 
 export const mockUserInfo: UserInfoType = {
+  nickName: "현아",
+  profileImage: "https://source.unsplash.com/random/?cat",
+}
+
+export const mockMyUserInfo: UserMyInfoType = {
+  id: 10,
   nickName: "현아",
   profileImage: "https://source.unsplash.com/random/?cat",
 }

--- a/src/seeds/user-mock.ts
+++ b/src/seeds/user-mock.ts
@@ -2,38 +2,38 @@ import { UserWaitingType } from "@/app/_waiting/types/game"
 import { UserInfoType } from "@/types/user"
 
 export const mockUserInfo: UserInfoType = {
-  nickname: "현아",
+  nickName: "현아",
   profileImage: "https://source.unsplash.com/random/?cat",
 }
 
 export const mockUserList: UserWaitingType[] = [
   {
     id: 1,
-    nickname: "얼음공주",
+    nickName: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },
   {
     id: 2,
-    nickname: "얼음공주",
+    nickName: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },
   {
     id: 3,
-    nickname: "얼음공주",
+    nickName: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },
   {
     id: 4,
-    nickname: "얼음공주",
+    nickName: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },
   {
     id: 5,
-    nickname: "얼음공주",
+    nickName: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },

--- a/src/seeds/user-mock.ts
+++ b/src/seeds/user-mock.ts
@@ -2,38 +2,38 @@ import { UserWaitingType } from "@/app/_waiting/types/game"
 import { UserInfoType } from "@/types/user"
 
 export const mockUserInfo: UserInfoType = {
-  nickName: "현아",
+  nickname: "현아",
   profileImage: "https://source.unsplash.com/random/?cat",
 }
 
 export const mockUserList: UserWaitingType[] = [
   {
     id: 1,
-    nickName: "얼음공주",
+    nickname: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },
   {
     id: 2,
-    nickName: "얼음공주",
+    nickname: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },
   {
     id: 3,
-    nickName: "얼음공주",
+    nickname: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },
   {
     id: 4,
-    nickName: "얼음공주",
+    nickname: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },
   {
     id: 5,
-    nickName: "얼음공주",
+    nickname: "얼음공주",
     profileImage: "https://source.unsplash.com/random/?cat",
     status: true,
   },

--- a/src/seeds/user-mock.ts
+++ b/src/seeds/user-mock.ts
@@ -2,8 +2,8 @@ import { UserWaitingType } from "@/app/_waiting/types/game"
 import { UserInfoType } from "@/types/user"
 
 export const mockUserInfo: UserInfoType = {
-  userNickName: "현아",
-  userProfileImage: "https://source.unsplash.com/random/?cat",
+  nickName: "현아",
+  profileImage: "https://source.unsplash.com/random/?cat",
 }
 
 export const mockUserList: UserWaitingType[] = [

--- a/src/store/my-info-store.ts
+++ b/src/store/my-info-store.ts
@@ -13,9 +13,9 @@ const useMyInfoStore = create<MyInfoStore>(set => ({
     profileImage: "",
   },
   setMyInfo: (newInfo: UserInfoType) =>
-    set({
+    set(() => ({
       myInfo: newInfo,
-    }),
+    })),
 }))
 
 export default useMyInfoStore

--- a/src/store/my-info-store.ts
+++ b/src/store/my-info-store.ts
@@ -1,10 +1,10 @@
 import { create } from "zustand"
 
 import { PostProfileResponse } from "@/app/_profile/api/post-profile"
-import { UserInfoType } from "@/types/user"
+import type { UserMyInfoType } from "@/types/user"
 
 type MyInfoStore = {
-  myInfo: (UserInfoType & { id: number }) | null
+  myInfo: UserMyInfoType | null
   setMyInfo: (newInfo: PostProfileResponse) => void
 }
 

--- a/src/store/my-info-store.ts
+++ b/src/store/my-info-store.ts
@@ -4,15 +4,15 @@ import { UserInfoType } from "@/types/user"
 
 type MyInfoStore = {
   myInfo: UserInfoType
-  setUserInfo: (newInfo: UserInfoType) => void
+  setMyInfo: (newInfo: UserInfoType) => void
 }
 
 const useMyInfoStore = create<MyInfoStore>(set => ({
   myInfo: {
-    nickName: "",
+    nickname: "",
     profileImage: "",
   },
-  setUserInfo: (newInfo: UserInfoType) =>
+  setMyInfo: (newInfo: UserInfoType) =>
     set({
       myInfo: newInfo,
     }),

--- a/src/store/my-info-store.ts
+++ b/src/store/my-info-store.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand"
+
+import { UserInfoType } from "@/types/user"
+
+type MyInfoStore = {
+  myInfo: UserInfoType
+  setUserInfo: (newInfo: UserInfoType) => void
+}
+
+const useMyInfoStore = create<MyInfoStore>(set => ({
+  myInfo: {
+    nickName: "",
+    profileImage: "",
+  },
+  setUserInfo: (newInfo: UserInfoType) =>
+    set({
+      myInfo: newInfo,
+    }),
+}))
+
+export default useMyInfoStore

--- a/src/store/my-info-store.ts
+++ b/src/store/my-info-store.ts
@@ -1,21 +1,22 @@
 import { create } from "zustand"
 
+import { PostProfileResponse } from "@/app/_profile/api/post-profile"
 import { UserInfoType } from "@/types/user"
 
 type MyInfoStore = {
-  myInfo: UserInfoType
-  setMyInfo: (newInfo: UserInfoType) => void
+  myInfo: (UserInfoType & { id: number }) | null
+  setMyInfo: (newInfo: PostProfileResponse) => void
 }
 
 const useMyInfoStore = create<MyInfoStore>(set => ({
-  myInfo: {
-    nickname: "",
-    profileImage: "",
-  },
-  setMyInfo: (newInfo: UserInfoType) =>
-    set(() => ({
-      myInfo: newInfo,
-    })),
+  myInfo: null,
+  setMyInfo: (newInfo: PostProfileResponse) =>
+    set(() => {
+      const { id, displayName, profileImage } = newInfo
+      return {
+        myInfo: { id, nickName: displayName, profileImage },
+      }
+    }),
 }))
 
 export default useMyInfoStore

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,4 @@
 export type UserInfoType = {
-  nickname: string
+  nickName: string
   profileImage: string
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,4 @@
 export type UserInfoType = {
-  userNickName: string
-  userProfileImage: string
+  nickName: string
+  profileImage: string
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,4 @@
 export type UserInfoType = {
-  nickName: string
+  nickname: string
   profileImage: string
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -2,3 +2,7 @@ export type UserInfoType = {
   nickName: string
   profileImage: string
 }
+
+export type UserMyInfoType = {
+  id: number
+} & UserInfoType


### PR DESCRIPTION
## 이슈 번호 #47

closes #47 

## 작업 분류

- [x] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경

## 작업 상세 내용

1. 사용자의 정보를 가지고있는 전역 변수를 추가하였습니다.

프로필을 등록할 경우 이후에 사용할 때 필요한 사용자의 아이디, 주소, 닉네임등이 저장이 됩니다.

```ts
export type UserMyInfoType = {
   nickName: string
  profileImage: string
  id: number
} 
```

사용 방법은 다음과 같습니다.

저같은 경우 `Type Safety`한 환경을 좋아하기 때문에 없을 경우 `return` 해주는 형태로 작성하였습니다. `throw Error`를 해도 될 것 같습니다.

```tsx
const Main: ActivityComponentType = () => {
  const myInfo = useMyInfoStore(state => state.myInfo)

  if (!myInfo) return

  return (
    <AppScreen>
      <MainScreen myInfo={myInfo} />
    </AppScreen>
  )
}
```



2. 만약 파람으로 `roomId`가 있다면 프로필을 설정함과 동시에 `Waiting` 스크린으로 이동하게 됩니다.

```tsx
  const onSubmit = async () => {
    try {
      const urlParams = new URL(location.href).searchParams
      const roomId = urlParams.get("roomId")

      const res = await postProfile({ nickName, profileImage: profileImage.src }, roomId)

      if (!res) throw new Error("사용자 정보 생성에 실패하였습니다.")

      setMyInfo(res)

      if (roomId) {
        replace("Waiting", { roomId })
      } else {
        replace("Main", {})
      }
    } catch (err) {
      if (err instanceof Error) {
        console.error(err.message)
      }
    }
  }
```

3. 맞는 roomId 인지 검사하는 로직을 제외하였습니다. 이유는 다음과 같습니다.

profile에서 바로 waiting으로 이동을 할 경우 검사할 수 있는 로직이 없습니다. 때문에 유효성 검사 API를 호출하는 것을 두 군데 (ex: main, profile)에서 개발할 것이 아니라면 Waiting에서 한 번 검사하는 것이 맞다고 생각합니다.

## 다음 할 일

만들어진 id와 프로필, 닉네임을 가지고 소켓 연결 진행하기

## 체크 리스트

- [x] main 브랜치 pull 받기

## 질문 사항

💬 **질문이 있어요!**

🔴 **이건 반드시 확인해 주세요!**
