### PR TITLE
feat: #45 small-talk 기능 완성

### DIFF
--- a/src/app/_small-talk/game-input/index.tsx
+++ b/src/app/_small-talk/game-input/index.tsx
@@ -28,21 +28,21 @@ const SmallTalkGameInput: ActivityComponentType = () => {
 
   const [userCount, setUserCount] = useState<UserCountType>({ answerCount: 0, totalCount })
   const { socket } = useSocketStore()
-  const { replace } = useFlow()
+  const { push } = useFlow()
 
   useEffect(() => {
     socket.on(SOCKET_EVENT.LISTEN_LIVE_USER_COUNT, res => setUserCount(res))
-    socket.on(SOCKET_EVENT.MOVE_TO_BLACK_TOPIC_RESULT, () => {
+    socket.on(SOCKET_EVENT.MOVE_TO_BLANK_TOPIC_RESULT, () => {
       socket.off(SOCKET_EVENT.LISTEN_LIVE_USER_COUNT)
-      socket.off(SOCKET_EVENT.MOVE_TO_BLACK_TOPIC_RESULT)
-      replace("SmallTalkGameResultList", { roomId, topic, topicId })
+      socket.off(SOCKET_EVENT.MOVE_TO_BLANK_TOPIC_RESULT)
+      push("SmallTalkGameResultList", { roomId, topic, topicId })
     })
 
     return () => {
       socket.off(SOCKET_EVENT.LISTEN_LIVE_USER_COUNT)
-      socket.off(SOCKET_EVENT.MOVE_TO_BLACK_TOPIC_RESULT)
+      socket.off(SOCKET_EVENT.MOVE_TO_BLANK_TOPIC_RESULT)
     }
-  }, [replace, roomId, socket, topic, topicId])
+  }, [push, roomId, socket, topic, topicId])
 
   const badRequest = !myInfo || !roomId || !topic || !topicId || !userCount
 

--- a/src/app/_small-talk/game-result-list/game-result-list-screen.tsx
+++ b/src/app/_small-talk/game-result-list/game-result-list-screen.tsx
@@ -13,7 +13,7 @@ type Props = {
   moveResultScreen: () => void
 }
 
-export default function SmallTalkGameResultListScreen({ topic, answerList, isAdmin }: Props) {
+export default function SmallTalkGameResultListScreen({ moveResultScreen, topic, answerList, isAdmin }: Props) {
   return (
     <div className="min-h-full bg-gray-950">
       <SmallTalkGameHeader isStart />
@@ -40,7 +40,7 @@ export default function SmallTalkGameResultListScreen({ topic, answerList, isAdm
           </ul>
         </SmallTalkGameResultBox>
         {isAdmin && (
-          <Button variant="full" size="max" className="mt-[15px]">
+          <Button onClick={moveResultScreen} variant="full" size="max" className="mt-[15px]">
             랜덤뽑기
           </Button>
         )}

--- a/src/app/_small-talk/game-result-list/index.tsx
+++ b/src/app/_small-talk/game-result-list/index.tsx
@@ -22,24 +22,29 @@ const SmallTalkGameResultList: ActivityComponentType = () => {
     topicId: number
     userList: WaitingUserType[]
   }
-  const { replace } = useFlow()
+  const { push } = useFlow()
   useEffect(() => {
     socket.on(SOCKET_EVENT.GET_USERS_ANSWER, res =>
       setAnswerList(() => res.filter((item: AnswerType) => item.answer !== "")),
     )
-    socket.on(SOCKET_EVENT.MOVE_TO_SMALL_TALK_RESULT, () => {
-      replace("SmallTalkResult", { roomId })
-    })
     socket.emit(SOCKET_EVENT.GET_USERS_ANSWER, { roomId, topicId })
 
     return () => {
       socket.off(SOCKET_EVENT.GET_USERS_ANSWER)
-      socket.off(SOCKET_EVENT.MOVE_TO_SMALL_TALK_RESULT)
     }
-  }, [answerList, replace, roomId, socket, topic, topicId, userList])
+  }, [push, roomId, socket, topic, topicId, userList])
+
+  useEffect(() => {
+    socket.on(SOCKET_EVENT.MOVE_TO_BLANK_TOPIC_RESULT, () =>
+      push("SmallTalkResult", { roomId, userAnswerList: answerList, topicId }),
+    )
+    return () => {
+      socket.off(SOCKET_EVENT.MOVE_TO_BLANK_TOPIC_RESULT)
+    }
+  }, [answerList, push, roomId, socket, topicId])
 
   const moveResultScreen = () => {
-    socket.emit(SOCKET_EVENT.MOVE_TO_SMALL_TALK_RESULT, { roomId })
+    socket.emit(SOCKET_EVENT.MOVE_TO_BLANK_TOPIC_RESULT, roomId)
   }
 
   return (

--- a/src/app/_small-talk/game-result/game-result-screen.stories.tsx
+++ b/src/app/_small-talk/game-result/game-result-screen.stories.tsx
@@ -35,7 +35,7 @@ Admin.args = {
   moveToMainRoom: mockFunction,
   moveToWaitingRoom: mockFunction,
   onReset: mockFunction,
-  isTryAllowed: "true",
+  isTryAllowed: true,
 }
 User.args = {
   isAdmin: false,
@@ -45,7 +45,7 @@ User.args = {
   moveToMainRoom: mockFunction,
   moveToWaitingRoom: mockFunction,
   onReset: mockFunction,
-  isTryAllowed: "true",
+  isTryAllowed: true,
 }
 Phone.args = {
   isAdmin: false,
@@ -55,7 +55,7 @@ Phone.args = {
   moveToMainRoom: mockFunction,
   moveToWaitingRoom: mockFunction,
   onReset: mockFunction,
-  isTryAllowed: "true",
+  isTryAllowed: false,
 }
 
 export default meta

--- a/src/app/_small-talk/game-result/game-result-screen.tsx
+++ b/src/app/_small-talk/game-result/game-result-screen.tsx
@@ -9,6 +9,7 @@ import resetIcon from "@/assets/svgs/small-talk/reset.svg"
 import resetHint from "@/assets/svgs/small-talk/reset-hint.svg"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/avatar"
 import { Button } from "@/components/button"
+import useBlankGuideStore from "@/store/blank-guide-store"
 import { UserInfoType } from "@/types/user"
 
 import SmallTalkGameBanner from "../components/game-banner/game-banner"
@@ -39,14 +40,14 @@ export default function SmallTalkGameResultScreen({
   const { nickName, profileImage } = selectUserInfo
 
   const [isAnimationVisible, setIsAnimationVisible] = useState(true)
-  const [isResetHintVisible, setIsResetHintVisible] = useState(true)
+  const { isFirst, setNotFirst } = useBlankGuideStore()
 
   const handleAnimationComplete = () => {
     setIsAnimationVisible(false)
   }
 
   const hintClose = () => {
-    setIsResetHintVisible(false)
+    setNotFirst()
   }
 
   return (
@@ -68,7 +69,7 @@ export default function SmallTalkGameResultScreen({
         <SmallTalkGameResultBox>
           {isAdmin && isTryAllowed && (
             <div className="relative">
-              {isResetHintVisible && (
+              {isFirst && (
                 <div className="absolute right-[11px] top-[11px] z-[2] flex flex-col items-end">
                   <div className="h-10 w-10 rounded-full border-2 border-gray-25" />
                   <Image onClick={hintClose} src={resetHint} alt="reset-hint" />

--- a/src/app/_small-talk/game-result/game-result-screen.tsx
+++ b/src/app/_small-talk/game-result/game-result-screen.tsx
@@ -20,7 +20,7 @@ type Props = {
   selectUserInfo: UserInfoType
   selectAnswer: string
   isAdmin: boolean
-  isTryAllowed?: "true" | "false"
+  isTryAllowed?: boolean
   onReset?: () => void
   moveToWaitingRoom?: () => void
   moveToMainRoom?: () => void
@@ -66,7 +66,7 @@ export default function SmallTalkGameResultScreen({
           selectAnswer={selectAnswer}
         />
         <SmallTalkGameResultBox>
-          {isAdmin && isTryAllowed === "true" && (
+          {isAdmin && isTryAllowed && (
             <div className="relative">
               {isResetHintVisible && (
                 <div className="absolute right-[11px] top-[11px] z-[2] flex flex-col items-end">

--- a/src/app/_small-talk/game-result/index.tsx
+++ b/src/app/_small-talk/game-result/index.tsx
@@ -60,8 +60,9 @@ const SmallTalkGameResult: ActivityComponentType = () => {
     socket.emit(SOCKET_EVENT.END_GAME, { roomId, userId: myInfo.id })
     replace("Main", {})
   }
-  console.log(selectInfo)
+
   const { selectAnswer, topic, userInfo } = selectInfo
+
   return (
     <AppScreen>
       <SmallTalkGameResultScreen

--- a/src/constants/apis.ts
+++ b/src/constants/apis.ts
@@ -32,9 +32,9 @@ export const SOCKET_EVENT = {
   MOVE_TO_MBTI_LOADING: "move-to-mbti-loading",
   MOVE_TO_MBTI_RESULT: "move-to-mbti-result",
   LISTEN_LIVE_USER_COUNT: "listen-live-user-count",
-  MOVE_TO_BLACK_TOPIC_RESULT: "move-to-blank-topic-result",
-  MOVE_TO_SMALL_TALK_RESULT: "move-to-small-talk-result",
+  MOVE_TO_BLANK_TOPIC_RESULT: "move-to-blank-topic-result",
   SEND_USER_ANSWER: "send-user-answer",
   GET_USERS_ANSWER: "get-users-answer",
-  GET_SMALL_TALK_RANDOM_ANSWER: "get-small-talk-random-answer",
+  GET_BLANK_TOPIC_RANDOM_ANSWER: "get-blank-topic-random-answer",
+  DRAW_AGAIN_USER_ANSWER: "draw-again-user-answer",
 } as const

--- a/src/store/blank-guide-store.ts
+++ b/src/store/blank-guide-store.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand"
+
+type BlankGuideStore = {
+  isFirst: boolean
+  setNotFirst: () => void
+}
+
+const useBlankGuideStore = create<BlankGuideStore>(set => ({
+  isFirst: true,
+  setNotFirst: () =>
+    set({
+      isFirst: false,
+    }),
+}))
+
+export default useBlankGuideStore

--- a/src/types/small-talk.ts
+++ b/src/types/small-talk.ts
@@ -12,7 +12,9 @@ export type AnswerType = {
 
 export type SmallTalkResult = {
   userInfo: UserInfoType
-  topic: string
-  selectAnswer: string
-  isTryAllowed: "true" | "false"
+  topic: {
+    id: number
+    description: string
+  }
+  selectAnswer: [{ answer: string }]
 }


### PR DESCRIPTION
## 이슈 번호 #45

## 작업 분류

- [x] 신규 기능

## 작업 상세 내용

https://github.com/dnd-side-project/dnd-10th-1-frontend/assets/115636461/d3e710d0-6ab5-4cc4-9077-f791fb80f9d5

### small-talk 기능을 완성하였습니다.

#### 입력 스크린

모든 유저들이 입력을 마쳤을 경우 혹은 타이머가 0초가 되었을 경우 다음 페이지로 넘어갑니다.

#### 리스트 스크린

방장이 랜덤 뽑기 버튼을 누를 경우 모든 유저가 다음 페이지로 넘어갑니다.

#### 랜덤뽑기 스크린

선택된 랜덤한 답변과 그에 맞는 유저의 정보가 보여집니다.

## 다음 할 일

### 버그가 있습니다. 둘 다 서버측에서 수정이 가능해져야 합니다.

1. 랜덤뽑기의 새로고침이 한번만 가능합니다.

## 체크 리스트

- [x] main 브랜치 pull 받기
